### PR TITLE
upgrade webpack-cli to fix build error

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "react-hot-loader": "^4.1.0",
     "style-loader": "^0.20.3",
     "webpack": "^4.5.0",
-    "webpack-cli": "^2.0.14",
+    "webpack-cli": "^3.1.1",
     "webpack-dev-server": "^3.1.3",
     "worker-loader": "^1.1.1"
   }


### PR DESCRIPTION
This fixes #13 

I upgraded the webpack-cli version in `package.json`, which appears to fix the `TypeError: Cannot read property 'properties' of undefined` build error.

More details here:
https://github.com/webpack/webpack-cli/issues/607