### PR TITLE
Handle content-type headers which contain subtype

### DIFF
--- a/src/actions/scenes/index.js
+++ b/src/actions/scenes/index.js
@@ -91,7 +91,11 @@ export function addSceneFromIndex(url, attribution, pipeline) {
         throw new Error(`Failed to fetch ${url}`);
       }
 
-      const contentType = headerResponse.headers.get('content-type');
+      let contentType = headerResponse.headers.get('content-type');
+      if (contentType) {
+        // Keep only the main type (before first ';')
+        contentType = contentType.split(';')[0].trim();
+      }
 
       if (contentType === 'text/html') {
         const relUrl = url.endsWith('/') ? url : url.substring(0, url.lastIndexOf('/'));


### PR DESCRIPTION
The content-type header can contain additional information after the main type, see [RFC7231](https://tools.ietf.org/html/rfc7231#section-3.1.1.1).

This can break the `contentType === 'image/tiff'` check further down.

An example is [this GeoTIFF file](https://data.geo.admin.ch/ch.swisstopo.pixelkarte-farbe-pk25.noscale/swiss-map-raster25_2014_1194/swiss-map-raster25_2014_1194_krel_1.25_2056.tif) which has the content-type header set to `image/tiff; application=geotiff; profile=cloud-optimized`.